### PR TITLE
Output position-only JointState

### DIFF
--- a/joint_trajectory_follower.orogen
+++ b/joint_trajectory_follower.orogen
@@ -4,14 +4,14 @@ version "0.1"
 import_types_from "std"
 import_types_from "base"
 
-# Periodically emits a joint position based on a JointTrajectory 
-# 
+# Periodically emits a joint position based on a JointTrajectory
+#
 # Does simple linear interpolation between two samples in the trajectory
 task_context "PositionSamplingTask" do
     needs_configuration
 
     property "period", "/base/Time"
-    
+
     # The trajectory
     input_port "trajectory", "/base/JointsTrajectory"
 
@@ -20,8 +20,10 @@ task_context "PositionSamplingTask" do
 
     # The trajectory is invalid
     exception_states :INVALID_TRAJECTORY
-    
+
     # The given trajectory's first time is not null
     exception_states :TRAJECTORY_START_TIME_NON_NULL
-end
 
+    #The given trajectory has no name joints
+    exception_states :INVALID_JOINT_NAMES
+end

--- a/tasks/PositionSamplingTask.cpp
+++ b/tasks/PositionSamplingTask.cpp
@@ -56,12 +56,7 @@ bool PositionSamplingTask::updateTrajectory()
         exception(TRAJECTORY_START_TIME_NON_NULL);
         throw std::runtime_error("received trajectory with a non-null start time");
     }
-    else if(mTrajectory.names.empty() && mTrajectory.names.size() != mTrajectory.elements.size())
-    {
-        exception(INVALID_JOINT_NAMES);
-        throw std::runtime_error("received trajectory with no joint names");
-    }
-
+   
     mCurrentStep = 0;
     mTrajectorySize = 0;
     if (!mTrajectory.elements.empty())

--- a/tasks/PositionSamplingTask.cpp
+++ b/tasks/PositionSamplingTask.cpp
@@ -46,7 +46,6 @@ bool PositionSamplingTask::updateTrajectory()
         return false;
     else if (state == RTT::OldData)
         return true;
-
     if (!mTrajectory.isValid())
     {
         exception(INVALID_TRAJECTORY);
@@ -56,6 +55,11 @@ bool PositionSamplingTask::updateTrajectory()
     {
         exception(TRAJECTORY_START_TIME_NON_NULL);
         throw std::runtime_error("received trajectory with a non-null start time");
+    }
+    else if(mTrajectory.names.empty() && mTrajectory.names.size() != mTrajectory.elements.size())
+    {
+        exception(INVALID_JOINT_NAMES);
+        throw std::runtime_error("received trajectory with no joint names");
     }
 
     mCurrentStep = 0;

--- a/tasks/PositionSamplingTask.hpp
+++ b/tasks/PositionSamplingTask.hpp
@@ -33,7 +33,7 @@ Does simple linear interpolation between two samples in the trajectory
         uint64_t mCurrentStep;
         uint64_t updateCurrentStep(base::Time t);
         base::JointsTrajectory mTrajectory;
-        void getJointsAtStep(uint64_t step, base::samples::Joints& result);
+        void getPositionCmdAtStep(uint64_t step, base::samples::Joints& result);
         base::Time getTimeAtStep(uint64_t step) const;
 
         /** Update the trajectory from the port, if needed
@@ -52,7 +52,7 @@ Does simple linear interpolation between two samples in the trajectory
         /** TaskContext constructor for PositionSamplingTask
          * \param name Name of the task. This name needs to be unique to make it identifiable for nameservices.
          * \param engine The RTT Execution engine to be used for this task, which serialises the execution of all commands, programs, state machines and incoming events for a task.
-         * 
+         *
          */
         PositionSamplingTask(std::string const& name, RTT::ExecutionEngine* engine);
 
@@ -123,4 +123,3 @@ Does simple linear interpolation between two samples in the trajectory
 }
 
 #endif
-

--- a/test/test_PositionSamplingTask.rb
+++ b/test/test_PositionSamplingTask.rb
@@ -48,9 +48,9 @@ describe 'PositionSamplingTask' do
     end
 
 
-    def setup_and_read_samples(names: [], times: [], elements: [], sample_count: 10)
+    def setup_and_read_samples(times: [], elements: [], sample_count: 10)
         traj = Types.base.JointsTrajectory.new(
-            names: names,
+            names: [],
             times: times,
             elements: elements)
 
@@ -73,11 +73,9 @@ describe 'PositionSamplingTask' do
 
     it "sends one sample per cycle when there are no times specified" do
         samples = setup_and_read_samples(
-            names: ['joint 1'],
             elements: [[Types.base.JointState.new(position: 0), Types.base.JointState.new(position: 1)]],
             sample_count: 10)
 
-        assert_equal ['joint 1'], samples[0].names
         assert_matches_period samples
 
         positions = samples.map { |s| s.elements[0].position }
@@ -86,7 +84,6 @@ describe 'PositionSamplingTask' do
 
     it "sub-samples the trajectory" do
         samples = setup_and_read_samples(
-            names: ['joint 1'],
             times: [Time.at(0), Time.at(1)],
             elements: [[Types.base.JointState.new(position: 0), Types.base.JointState.new(position: 1)]],
             sample_count: 15)


### PR DESCRIPTION
Only position cmds are being forwarded to Gazebo in order to be consistent with the interface.

also added some unit test to the joint names checking